### PR TITLE
tabata update

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useEffect, useState } from "react";
 import * as ReactDOM from "react-dom";
-import styled from "styled-components";
+import styled, { createGlobalStyle } from "styled-components";
 import { Stopwatch } from "./pages/stopwatch";
 import { Tabata } from "./pages/tabata";
 import { Timer } from "./pages/timer";
@@ -69,6 +69,7 @@ const App = () => {
     });
     return (
         <div>
+            <GlobalStyles />
             <PaddedCenteredContainer>
                 <TimerChooser />
             </PaddedCenteredContainer>
@@ -85,5 +86,11 @@ const App = () => {
         </div>
     );
 };
+
+const GlobalStyles = createGlobalStyle`
+    * {
+        box-sizing: border-box;
+    }
+`;
 
 ReactDOM.render(<App />, document.getElementById("react"));

--- a/src/components/shared_ui.tsx
+++ b/src/components/shared_ui.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import * as colors from "libs/colors";
 
 export const StartStopButton = ({
     running,
@@ -10,7 +11,7 @@ export const StartStopButton = ({
 }) => {
     const text = running ? "Stop" : "Start";
     return (
-        <Button color={running ? "#f00" : "#0edb0e"} onClick={onClick}>
+        <Button color={running ? colors.Red : colors.Green} onClick={onClick} textColor={running ? "white" : "black"}>
             {text}
         </Button>
     );
@@ -18,12 +19,14 @@ export const StartStopButton = ({
 
 interface Props {
     color?: string;
+    textColor?: string;
 }
 export const Button = styled.button<Props>`
     padding: 4px;
     border-radius: 4px;
     font-size: 20px;
     background: ${(props) => (props.color ? props.color : "white")};
+    color: ${(props) => (props.textColor ? props.textColor : "black")};
 `;
 
 export const ClearButton = Button;

--- a/src/components/tabata.tsx
+++ b/src/components/tabata.tsx
@@ -16,10 +16,11 @@ import {
 import { TimeSinceState } from "./shared_interfaces";
 import { TabataTimeRenderer, timeSoFar } from "./time_renderer";
 import { globalYoutubeController } from "libs/youtube_global_controls";
+import _ from "lodash";
 
 interface TabataState extends TimeSinceState {
-    numberOfRounds: number;
-    exercisesPerRound: number;
+    numberOfRounds: number | "";
+    exercisesPerRound: number | "";
     workTime: number;
     restTime: number;
 }
@@ -91,7 +92,9 @@ export class Tabata extends React.Component<{}, TabataState> {
                         console.log("Rest start.");
                         hushPlay(restSound);
                     }}
-                    {...this.state}
+                    numberOfRounds={this.state.numberOfRounds !== "" ? this.state.numberOfRounds : 1}
+                    exercisesPerRound={this.state.exercisesPerRound !== "" ? this.state.exercisesPerRound : 1}
+                    {..._.omit(this.state, "numberOfRounds", "exercisesPerRound")}
                 />
                 <RowDisplayWithEvenSpacing>
                     <StartStopButton
@@ -120,7 +123,7 @@ export class Tabata extends React.Component<{}, TabataState> {
                                         numberOfRounds:
                                             Number.parseInt(
                                                 ev.currentTarget.value
-                                            ) || 0,
+                                            ) || "",
                                     })
                                 }
                             ></input>
@@ -135,7 +138,7 @@ export class Tabata extends React.Component<{}, TabataState> {
                                         exercisesPerRound:
                                             Number.parseInt(
                                                 ev.currentTarget.value
-                                            ) || 0,
+                                            ) || "",
                                     })
                                 }
                             ></input>

--- a/src/components/time_renderer.tsx
+++ b/src/components/time_renderer.tsx
@@ -16,10 +16,10 @@ export function timeSoFar(
         timeSinceLastStarted = moment.duration(moment().diff(lastStartedAt));
     }
     // Uncomment to accelerate time for 'testing'
-    // timeSinceLastStarted
-    //     .add(timeSinceLastStarted)
-    //     .add(timeSinceLastStarted)
-    //     .add(timeSinceLastStarted);
+    timeSinceLastStarted
+        .add(timeSinceLastStarted)
+        .add(timeSinceLastStarted)
+        .add(timeSinceLastStarted);
     if (previouslyAccumulated) {
         return timeSinceLastStarted.add(previouslyAccumulated);
     } else {
@@ -122,6 +122,9 @@ export class TabataTimeRenderer extends React.Component<TabataProps, {}> {
     getCurrentRound(timeRemaining: Duration) {
         return this.tabataHelper.roundAt(timeRemaining.asSeconds());
     }
+    getTimeRemainingInExercise(timeRemaining: Duration) {
+        return this.getCurrentRound(timeRemaining).remainingTimeInState(timeRemaining.asSeconds());
+    }
     isWorkTime(timeRemaining: Duration): boolean {
         // We want to start with the work interval.
         return this.tabataHelper.stateAt(timeRemaining.asSeconds()) === "work";
@@ -170,39 +173,103 @@ export class TabataTimeRenderer extends React.Component<TabataProps, {}> {
         }
         return (
             <div>
-                <TimeDisplay>
-                    {timeStringNoMillis}
-                    <MillisDisplay>{timeStringMillis}</MillisDisplay>
-                </TimeDisplay>
-                <SideBySide>
-                    <div>
+                <TabataRow>
+                    <TimeDisplay>
+                        {this.getTimeRemainingInExercise(timeRemaining)}
+                        <MillisDisplay>{timeStringMillis}</MillisDisplay>
+                    </TimeDisplay>
+                </TabataRow>
+                <TabataRow>
+                    <SideBySide>
+                    <ExerciseAndRoundCountContainer>
                         Exercise{" "}
-                        {this.getCurrentRound(timeRemaining).exerciseNumber} of{" "}
+                        <Big>{this.getCurrentRound(timeRemaining).exerciseNumber}</Big>
+                        of{" "}
                         {this.props.exercisesPerRound}
-                    </div>
-                    <div>
-                        Round {this.getCurrentRound(timeRemaining).roundNumber}{" "}
+                    </ExerciseAndRoundCountContainer>
+                    <ExerciseAndRoundCountContainer>
+                        Round <Big>{this.getCurrentRound(timeRemaining).roundNumber}{" "}</Big>
                         of {this.props.numberOfRounds}
-                    </div>
-                </SideBySide>
-                <WorkRestDisplay
-                    isRunning={this.props.running}
-                    isWorkTime={this.isWorkTime(timeRemaining)}
-                    onWork={this.props.onWork}
-                    onRest={this.props.onRest}
-                />
+                    </ExerciseAndRoundCountContainer>
+                    </SideBySide>
+                </TabataRow>
+                <TabataRow>
+                    <ProgressBar>
+                    {Array(this.props.numberOfRounds).fill(null).map(round =>
+                        <ProgressRound completed={round >= (this.props.numberOfRounds - this.getCurrentRound(timeRemaining).roundNumber)}>
+                            {Array(this.props.exercisesPerRound - this.getCurrentRound(timeRemaining).exerciseNumber).fill(null).map(exercise =>
+                                <ProgressExercise completed={exercise >= (this.props.exercisesPerRound - this.getCurrentRound(timeRemaining).exerciseNumber)}/>
+                            )}
+                        </ProgressRound>
+                    )}
+                    </ProgressBar>
+                </TabataRow>
+                <TabataRow>
+                    <WorkRestDisplay
+                        isRunning={this.props.running}
+                        isWorkTime={this.isWorkTime(timeRemaining)}
+                        onWork={this.props.onWork}
+                        onRest={this.props.onRest}
+                    />
+                </TabataRow>
             </div>
         );
     }
 }
 
+const Big = styled.span`font-size: 2em;`;
+
+const ExerciseAndRoundCountContainer = styled.div`
+    display: inline-block;
+    font-size: 1.5em;
+    padding: 8px;
+    width: 50%;
+    text-align: center;
+    border-left: 1px solid black;
+`;
+
+const ProgressBar = styled.div`
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    margin: 4px;
+    height: 16px;
+    background-color: lightgray;
+    border: 1px solid black;
+`;
+    
+const ProgressRound = styled.div<{completed?: boolean}>`
+    border: 1px solid green;
+    width: 30px;
+    height: 16px;
+    flex-basis: 1em;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: row;
+    ${completed => completed && "border: none;"}
+`;
+const ProgressExercise = styled.div<{completed?: boolean}>`
+    border: 1px solid grey;
+    background-color: lightblue;
+    width: 10px;
+    height: 16px;
+    flex-basis: 1em;
+    flex-grow: 1;
+    ${completed => completed && "border: none;"}
+`;
+
+const TabataRow = styled.div`
+    display: flex;
+    border: 1px solid black;
+`;
+
 const SideBySide = styled.div`
     display: flex;
     direction: row;
     justify-content: space-between;
-    padding: 16px 4px;
     font-size: larger;
     font-family: sans-serif;
+    width: 100%;
 `;
 
 interface WorkRestDisplayProps {

--- a/src/components/time_renderer.tsx
+++ b/src/components/time_renderer.tsx
@@ -171,37 +171,38 @@ export class TabataTimeRenderer extends React.Component<TabataProps, {}> {
             this.justOnceAtTheStart = true;
             this.props.onWork();
         }
+        const seconds = this.getTimeRemainingInExercise(timeRemaining).toFixed(0);
         return (
             <div>
                 <TabataRow>
                     <TimeDisplay>
-                        {this.getTimeRemainingInExercise(timeRemaining)}
+                        {seconds}
                         <MillisDisplay>{timeStringMillis}</MillisDisplay>
                     </TimeDisplay>
                 </TabataRow>
                 <TabataRow>
                     <SideBySide>
-                    <ExerciseAndRoundCountContainer>
-                        Exercise{" "}
-                        <Big>{this.getCurrentRound(timeRemaining).exerciseNumber}</Big>
-                        of{" "}
-                        {this.props.exercisesPerRound}
-                    </ExerciseAndRoundCountContainer>
-                    <ExerciseAndRoundCountContainer>
-                        Round <Big>{this.getCurrentRound(timeRemaining).roundNumber}{" "}</Big>
-                        of {this.props.numberOfRounds}
-                    </ExerciseAndRoundCountContainer>
+                        <ExerciseAndRoundCountContainer>
+                            Round <Big>{this.getCurrentRound(timeRemaining).roundNumber}{" "}</Big>
+                            of {this.props.numberOfRounds}
+                        </ExerciseAndRoundCountContainer>
+                        <ExerciseAndRoundCountContainer>
+                            Exercise{" "}
+                            <Big>{this.getCurrentRound(timeRemaining).exerciseNumber}</Big>
+                            of{" "}
+                            {this.props.exercisesPerRound}
+                        </ExerciseAndRoundCountContainer>
                     </SideBySide>
                 </TabataRow>
                 <TabataRow>
                     <ProgressBar>
-                    {Array(this.props.numberOfRounds).fill(null).map(round =>
-                        <ProgressRound completed={round >= (this.props.numberOfRounds - this.getCurrentRound(timeRemaining).roundNumber)}>
-                            {Array(this.props.exercisesPerRound - this.getCurrentRound(timeRemaining).exerciseNumber).fill(null).map(exercise =>
-                                <ProgressExercise completed={exercise >= (this.props.exercisesPerRound - this.getCurrentRound(timeRemaining).exerciseNumber)}/>
-                            )}
-                        </ProgressRound>
-                    )}
+                        {Array(this.props.numberOfRounds).fill(null).map(round =>
+                            <ProgressRound completed={round >= (this.props.numberOfRounds - this.getCurrentRound(timeRemaining).roundNumber)}>
+                                {Array(this.props.exercisesPerRound - this.getCurrentRound(timeRemaining).exerciseNumber).fill(null).map(exercise =>
+                                    <ProgressExercise completed={exercise >= (this.props.exercisesPerRound - this.getCurrentRound(timeRemaining).exerciseNumber)} />
+                                )}
+                            </ProgressRound>
+                        )}
                     </ProgressBar>
                 </TabataRow>
                 <TabataRow>
@@ -237,8 +238,8 @@ const ProgressBar = styled.div`
     background-color: lightgray;
     border: 1px solid black;
 `;
-    
-const ProgressRound = styled.div<{completed?: boolean}>`
+
+const ProgressRound = styled.div<{ completed?: boolean }>`
     border: 1px solid green;
     width: 30px;
     height: 16px;
@@ -248,7 +249,7 @@ const ProgressRound = styled.div<{completed?: boolean}>`
     flex-direction: row;
     ${completed => completed && "border: none;"}
 `;
-const ProgressExercise = styled.div<{completed?: boolean}>`
+const ProgressExercise = styled.div<{ completed?: boolean }>`
     border: 1px solid grey;
     background-color: lightblue;
     width: 10px;
@@ -308,6 +309,7 @@ const WorkRestDisplayRoot = styled.div<{ workTime: boolean }>`
     padding: 24px;
     font-size: 2rem;
     font-family: sans-serif;
+    width: 100%;
 `;
 
 interface CountdownProps extends TimeSinceState {

--- a/src/components/time_renderer.tsx
+++ b/src/components/time_renderer.tsx
@@ -196,12 +196,18 @@ export class TabataTimeRenderer extends React.Component<TabataProps, {}> {
                 </TabataRow>
                 <TabataRow>
                     <ProgressBar>
-                        {Array(this.props.numberOfRounds).fill(null).map(round =>
-                            <ProgressRound completed={round >= (this.props.numberOfRounds - this.getCurrentRound(timeRemaining).roundNumber)}>
-                                {Array(this.props.exercisesPerRound - this.getCurrentRound(timeRemaining).exerciseNumber).fill(null).map(exercise =>
-                                    <ProgressExercise completed={exercise >= (this.props.exercisesPerRound - this.getCurrentRound(timeRemaining).exerciseNumber)} />
+                        {Array(this.props.numberOfRounds).fill(null).map((_, round) => {
+                            const isCompletedRound = round > (this.props.numberOfRounds - this.getCurrentRound(timeRemaining).roundNumber);
+                            const isCurrentRound = round === this.props.numberOfRounds - this.getCurrentRound(timeRemaining).roundNumber;
+                            return <ProgressRound completed={isCompletedRound}>
+                                {Array(this.props.exercisesPerRound).fill(null).map((_, exercise) => {
+                                    const isCompletedExercise = exercise > (this.props.exercisesPerRound - this.getCurrentRound(timeRemaining).exerciseNumber);
+                                    const isCurrentExercise = exercise === this.props.exercisesPerRound - this.getCurrentRound(timeRemaining).exerciseNumber;
+                                    return <ProgressExercise completed={isCompletedRound || (isCurrentRound && isCompletedExercise)} />
+                                }
                                 )}
                             </ProgressRound>
+                        }
                         )}
                     </ProgressBar>
                 </TabataRow>
@@ -234,29 +240,29 @@ const ProgressBar = styled.div`
     flex-direction: row;
     width: 100%;
     margin: 4px;
-    height: 16px;
-    background-color: lightgray;
-    border: 1px solid black;
+    height: 20px;
+    padding: 2px;
+    background-color: black;
 `;
 
-const ProgressRound = styled.div<{ completed?: boolean }>`
-    border: 1px solid green;
+const ProgressRound = styled.div<{ completed: boolean }>`
+    visibility: ${props => props.completed ? "hidden" : "visible"};
+    border: 2px solid black;
     width: 30px;
-    height: 16px;
+    height: 100%;
     flex-basis: 1em;
     flex-grow: 1;
     display: flex;
     flex-direction: row;
-    ${completed => completed && "border: none;"}
 `;
-const ProgressExercise = styled.div<{ completed?: boolean }>`
+const ProgressExercise = styled.div<{ completed: boolean }>`
+    visibility: ${props => props.completed ? "hidden" : "visible"};
     border: 1px solid grey;
-    background-color: lightblue;
     width: 10px;
-    height: 16px;
+    height: 100%;
     flex-basis: 1em;
     flex-grow: 1;
-    ${completed => completed && "border: none;"}
+    background-color: blue;
 `;
 
 const TabataRow = styled.div`

--- a/src/components/time_renderer.tsx
+++ b/src/components/time_renderer.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import styled from "styled-components";
 import { TabataConfig, TabataLogicHelper } from "../libs/tabata_logic_helper";
 import { TimeSinceState } from "./shared_interfaces";
+import * as colors from "libs/colors";
 
 export function timeSoFar(
     lastStartedAt: Moment | undefined,
@@ -175,26 +176,6 @@ export class TabataTimeRenderer extends React.Component<TabataProps, {}> {
         return (
             <div>
                 <TabataRow>
-                    <TimeDisplay>
-                        {seconds}
-                        <MillisDisplay>{timeStringMillis}</MillisDisplay>
-                    </TimeDisplay>
-                </TabataRow>
-                <TabataRow>
-                    <SideBySide>
-                        <ExerciseAndRoundCountContainer>
-                            Round <Big>{this.getCurrentRound(timeRemaining).roundNumber}{" "}</Big>
-                            of {this.props.numberOfRounds}
-                        </ExerciseAndRoundCountContainer>
-                        <ExerciseAndRoundCountContainer>
-                            Exercise{" "}
-                            <Big>{this.getCurrentRound(timeRemaining).exerciseNumber}</Big>
-                            of{" "}
-                            {this.props.exercisesPerRound}
-                        </ExerciseAndRoundCountContainer>
-                    </SideBySide>
-                </TabataRow>
-                <TabataRow>
                     <ProgressBar>
                         {Array(this.props.numberOfRounds).fill(null).map((_, round) => {
                             const isCompletedRound = round > (this.props.numberOfRounds - this.getCurrentRound(timeRemaining).roundNumber);
@@ -219,7 +200,27 @@ export class TabataTimeRenderer extends React.Component<TabataProps, {}> {
                         onRest={this.props.onRest}
                     />
                 </TabataRow>
-            </div>
+                <TabataRow backgroundColor={(this.props.running || undefined) && (this.isWorkTime(timeRemaining) ? colors.Green : colors.Red)} color={(this.props.running || undefined) && (this.isWorkTime(timeRemaining) ? "black" : "white")}>
+                    <TimeDisplay>
+                        {seconds}
+                        <MillisDisplay>{timeStringMillis}</MillisDisplay>
+                    </TimeDisplay>
+                </TabataRow>
+                <TabataRow>
+                    <SideBySide>
+                        <ExerciseAndRoundCountContainer>
+                            Round <Big>{this.getCurrentRound(timeRemaining).roundNumber}{" "}</Big>
+                            of {this.props.numberOfRounds}
+                        </ExerciseAndRoundCountContainer>
+                        <ExerciseAndRoundCountContainer>
+                            Exercise{" "}
+                            <Big>{this.getCurrentRound(timeRemaining).exerciseNumber}</Big>
+                            of{" "}
+                            {this.props.exercisesPerRound}
+                        </ExerciseAndRoundCountContainer>
+                    </SideBySide>
+                </TabataRow>
+            </div >
         );
     }
 }
@@ -265,9 +266,11 @@ const ProgressExercise = styled.div<{ completed: boolean }>`
     background-color: blue;
 `;
 
-const TabataRow = styled.div`
+const TabataRow = styled.div<{ backgroundColor?: string, color?: string }>`
     display: flex;
     border: 1px solid black;
+    background-color: ${(props) => (props.backgroundColor !== undefined ? props.backgroundColor : "none")};
+    color: ${(props) => (props.color !== undefined ? props.color : "black")};
 `;
 
 const SideBySide = styled.div`
@@ -300,15 +303,15 @@ class WorkRestDisplay extends React.Component<WorkRestDisplayProps> {
     }
     render() {
         return (
-            <WorkRestDisplayRoot workTime={this.props.isWorkTime}>
+            <WorkRestDisplayRoot backgroundColor={(this.props.isRunning || undefined) && (this.props.isWorkTime ? colors.Green : colors.Red)} color={(this.props.isRunning || undefined) && (this.props.isWorkTime ? "black" : "white")}>
                 {this.props.isWorkTime ? "Work" : "Rest"}
             </WorkRestDisplayRoot>
         );
     }
 }
-const WorkRestDisplayRoot = styled.div<{ workTime: boolean }>`
-    background-color: ${(props) => (props.workTime ? "green" : "red")};
-    color: ${(props) => (props.workTime ? "black" : "white")};
+const WorkRestDisplayRoot = styled.div<{ backgroundColor?: string, color?: string }>`
+    background-color: ${(props) => (props.backgroundColor && props.backgroundColor || "none")};
+    color: ${(props) => props.color && props.color || "black"};
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/libs/colors.ts
+++ b/src/libs/colors.ts
@@ -1,0 +1,2 @@
+export const Green = "lightgreen";
+export const Red = "#e83b2b";

--- a/src/libs/tabata_logic_helper.ts
+++ b/src/libs/tabata_logic_helper.ts
@@ -11,6 +11,7 @@ class Round {
     rest: number;
     work: number;
     exerciseNumber: number;
+    end: number;
     stateAt(timeSeconds: number): TabataState {
         if (timeSeconds <= this.rest) {
             return "rest";
@@ -18,12 +19,21 @@ class Round {
             return "work";
         }
     }
+    remainingTimeInState(timeSeconds: number): number {
+        if (timeSeconds <= this.rest) {
+            return timeSeconds - this.end;
+        } else {
+            return timeSeconds - this.rest;
+        }
+    }
     constructor(
+        end: number,
         rest: number,
         work: number,
         roundNumber: number,
         exerciseNumber: number
     ) {
+        this.end = end;
         this.rest = rest;
         this.work = work;
         this.roundNumber = roundNumber;
@@ -31,6 +41,7 @@ class Round {
     }
     toJSON() {
         return {
+            end: formatTime(this.end),
             rest: formatTime(this.rest),
             work: formatTime(this.work),
             roundNumber: this.roundNumber,
@@ -64,10 +75,12 @@ export class TabataLogicHelper {
                 exercise < this.exercisesPerRound;
                 exercise += 1
             ) {
+                let endAt = secondsTotal;
                 let restAt = secondsTotal + this.secondsOfRest;
                 let workAt = restAt + this.secondsPerExercise;
                 this.rounds.push(
                     new Round(
+                        endAt,
                         restAt,
                         workAt,
                         this.numberOfRounds - round,

--- a/src/libs/tabata_logic_helper.ts
+++ b/src/libs/tabata_logic_helper.ts
@@ -100,7 +100,7 @@ export class TabataLogicHelper {
     roundAt(timeSeconds: number): Round {
         // The round begins with work
         if (this.rounds.length === 0) {
-            return new Round(0, 0, 0, 0);
+            return new Round(0, 0, 0, 0, 0);
         }
         if (timeSeconds > this.secondsTotal) {
             return this.rounds[this.rounds.length - 1];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,8 @@
     "compilerOptions": {
         "jsx": "react",
         "baseUrl": "src",
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "maxNodeModuleJsDepth": 0
     },
-    "exclude": [
-        "node_modules",
-    ]
+    "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- Update Tabata visualisation to show a progress bar.
- Fix parsing of empty values in round and exercise numbers.
- Make it more pretty by showing green and red in nicer colours and under the timer.

<img width="852" alt="Screenshot 2024-09-29 at 12 37 32 pm" src="https://github.com/user-attachments/assets/e12acc2a-17c9-4894-a145-8a86ce5b71bf">
<img width="851" alt="Screenshot 2024-09-29 at 12 37 37 pm" src="https://github.com/user-attachments/assets/1dbda871-2c75-46dd-b4bc-31f563012fc7">
<img width="851" alt="Screenshot 2024-09-29 at 12 37 39 pm" src="https://github.com/user-attachments/assets/096ba39c-6840-4de0-b3e8-4ff9fc173116">

